### PR TITLE
fix: get sonar project key

### DIFF
--- a/src/sonar/core.ts
+++ b/src/sonar/core.ts
@@ -29,7 +29,7 @@ export class Sonar {
     } catch (e: any) {
       Log.error(e.message);
       this.host = opt.host;
-      this.projectKey = opt.host;
+      this.projectKey = opt.projectKey;
     }
     this.qualityGate = new SonarReport({ host: this.host, projectKey: this.projectKey });
 


### PR DESCRIPTION
Nếu không có file sonar-project.properties thì sẽ lấy host và projectKey từ opt.

Tuy nhiên đoạn này đang gán nhầm `this.projectKey = opt.host` nên khi không có sonar-project.properties sẽ bị lỗi 
```
Error: Request failed with status code 404
```