### PR TITLE
fix: initialize empty data array for review comments creation which is not initialized by default

### DIFF
--- a/src/gitlab/core.ts
+++ b/src/gitlab/core.ts
@@ -94,7 +94,7 @@ export class GitlabMerge extends Gitlab implements GitMerge {
   async createReviewComments(
     params: GitReviewParam[]
   ): Promise<entity.Notes[] | boolean> {
-    let data: any;
+    const data: any[] = [];
     const version = await this.getVersion();
     if (!version) {
       return false;


### PR DESCRIPTION
Hi, we're trying to integrate this tool in our GitLab CI/CD pipelines as an alternative to SonarQube's Developer version. We identified, that this tool currently is unable to create review comments, as it tries to push the findings from SonarQube into an uninitialized array. Therefore we've created this PR to fix this issue :)

Thanks for this tool btw. 😊