### PR TITLE
feat: resolve env-variables in sonar-project.properties file

### DIFF
--- a/src/sonar/properties.ts
+++ b/src/sonar/properties.ts
@@ -3,6 +3,8 @@ import fs from "fs";
 const PROJECT_KEY_PROPERTY = "sonar.projectKey";
 const HOST_URL_PROPERTY = "sonar.host.url";
 
+const ENVIRONMENT_VARIABLE_REGEX = /^\$\{env\.(?<env>.*)\}$/;
+
 export class SonarProperties {
   projectDir: string;
   private properties: { [key: string]: string; } = {};
@@ -23,7 +25,13 @@ export class SonarProperties {
       if (data.length != 2) {
         continue;
       }
-      this.properties[data[0]] = data[1];
+
+      const match = ENVIRONMENT_VARIABLE_REGEX.exec(data[1]);
+      if (match?.groups?.env && process.env[match.groups.env]) {
+        this.properties[data[0]] = process.env[match.groups.env] as string;
+      } else {
+        this.properties[data[0]] = data[1];
+      }
     }
   }
 


### PR DESCRIPTION
Hi again 😊

As we currently trying to integrate this tool, we identified that it currently does not support environment variables specified in the `sonar-project.properties`. Environment variables inside the properties file [are officially supported](https://sonarsource.atlassian.net/browse/SQSCANNER-9) and we thought it would be great, if this tool would also support them.

We've implemented a change, that tests if a property contains a value containing an environment variable and resolves it to the specified value via `process.env`.

What do you think?