### PR TITLE
feat: Pull Request support if using SonarQube community version with community-branch-plugin installed

### DIFF
--- a/src/cli/core.ts
+++ b/src/cli/core.ts
@@ -57,7 +57,7 @@ export class Cli {
     this.sonarURL = this.argv.sonar.url ? this.argv.sonar.url : process.env.SONAR_URL;
     this.sonarToken = this.argv.sonar.token ? this.argv.sonar.token : process.env.SONAR_TOKEN;
     this.sonarProjectKey = this.argv.sonar.project_key ? this.argv.sonar.project_key : process.env.SONAR_PROJECT_KEY;
-    
+
     if (!this.validate()) {
       process.exit(1);
     }
@@ -124,7 +124,9 @@ export class Cli {
     const sonar = new Sonar({
       tokenKey: this.sonarToken,
       host: this.sonarURL,
-      projectKey: this.sonarProjectKey
+      projectKey: this.sonarProjectKey,
+      branchPluginEnabled: this.argv.sonarBranchPlugin,
+      branchPluginMergeId: parseInt(this.gitMergeID)
     });
 
     let gitMerge: GitMerge;

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -13,6 +13,7 @@ export enum Provide {
 export interface Arguments {
   _: ArgsOutput;
   provide: Provide;
+  sonarBranchPlugin?: boolean;
   skipScanner?: boolean;
   define: (string | number)[] | undefined;
   git: { [key: string]: string };
@@ -39,6 +40,12 @@ export function createOptions() {
     .option("skip-scanner", {
       group: "Global Options:",
       desc: "Skip run sonar-scanner",
+      default: false
+    })
+    .option("sonar-branch-plugin", {
+      alias: "b",
+      group: "Global Options:",
+      desc: "Enable SonarQube Community-Branch-Plugin support. Please make sure, that you've properly installed the plugin in SonarQube: https://github.com/mc1arke/sonarqube-community-branch-plugin",
       default: false
     })
     .option("define", {

--- a/src/quality-gate/core.ts
+++ b/src/quality-gate/core.ts
@@ -1,7 +1,7 @@
 import { Git, GitMerge, GitReviewParam } from "../git";
 import { Sonar } from "../sonar";
 
-const INTERVAL_SECONDS = 60;
+const INTERVAL_SECONDS = 300;
 
 declare global {
   interface Date {

--- a/src/sonar/entity.ts
+++ b/src/sonar/entity.ts
@@ -55,3 +55,13 @@ export interface Task {
 export interface Tasks {
   tasks: Task[];
 }
+
+export interface SonarApiRequestParameters {
+  projectKey?: string;
+  componentKeys?: string;
+  sinceLeakPeriod?: boolean;
+  createdAfter?: string;
+  pullRequest?: number;
+  p?: number;
+  ps?: number;
+}

--- a/src/sonar/report.ts
+++ b/src/sonar/report.ts
@@ -6,12 +6,18 @@ const IMAGE_DIR_LINK = "https://hsonar.s3.ap-southeast-1.amazonaws.com/images/";
 export class SonarReport {
   host?: string;
   projectKey?: string;
+  branchPluginEnabled?: boolean;
+  branchPluginMergeId?: number;
   constructor(opt: {
     host?: string;
     projectKey?: string;
+    branchPluginEnabled?: boolean;
+    branchPluginMergeId?: number;
   }) {
     this.host = opt.host;
     this.projectKey = opt.projectKey;
+    this.branchPluginEnabled = opt.branchPluginEnabled;
+    this.branchPluginMergeId = opt.branchPluginMergeId;
   }
 
   private capitalize(text: string) {
@@ -57,12 +63,22 @@ export class SonarReport {
     return level[val];
   }
 
+  private appendPullRequestIdIfBranchPluginEnabled(url: string) {
+    if (this.branchPluginEnabled) {
+      return `${url}&pullRequest=${this.branchPluginMergeId}`
+    }
+
+    return url;
+  }
+
   private getIssueURL(type: string) {
-    return this.host + `/project/issues?id=${this.projectKey}&resolved=false&sinceLeakPeriod=true&types=${type}`;
+    const url = this.host + `/project/issues?id=${this.projectKey}&resolved=false&sinceLeakPeriod=true&types=${type}`;
+    return this.appendPullRequestIdIfBranchPluginEnabled(url);
   }
 
   private getMetricURL(metric: string) {
-    return this.host + `/project/issues?id=${this.projectKey}&metric=${metric}&view=list`;
+    const url = this.host + `/project/issues?id=${this.projectKey}&metric=${metric}&view=list`;
+    return this.appendPullRequestIdIfBranchPluginEnabled(url);
   }
 
   private getIssueSecurity(projectStatus: ProjectStatus) {
@@ -121,7 +137,7 @@ export class SonarReport {
       status = "failed";
     }
 
-    const report = `# SonarQube Code Analytics 
+    const report = `# SonarQube Code Analytics
 ## Quality Gate ${status}
 
 ${this.icon(status)}


### PR DESCRIPTION
Hello again 😄

We have another Pull Request as we identified that this tool currently is unable to determine the correct issues and Quality Gate data when using SonarQube community version with the [community-branch-plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin) installed.

The issue is, that if the plugin is installed and enabled in SonarQube, the SonarQube API requires the Pull/Merge Request ID for which the issues and quality gate should be retrieved. The Pull/Merge Request ID can be specified by the query parameter `&pullRequest=[ID]`.

Therefore we've added a new flag (`--sonar-branch-plugin` or `-b`), with which the community-branch-plugin support can be enabled in this tool. Then the `pullRequest` query parameter (we've added a TypeScript type for this matter) will be appended to each SonarQube API request and the Quality Gate Pull/Merge Request decoration comment URLs. We also needed to increase the `INTERVAL_SECONDS` variable to 5 minutes to be able to retrieve the newly created issues in SonarQube as there is some delay caused by our GitLab CI/CD jobs. 1 minute is not enough. Maybe we should make this configurable too?

I know this is a fairly large change. We've tested the changes with our self-hosted GitLab and SonarQube 10.3 with the community-branch-plugin [installed in version 1.16.1](https://github.com/mc1arke/sonarqube-community-branch-plugin/pull/797#issuecomment-1719085033) (I hope that official support of SonarQube 10.3 doesn't take too long 🤞). It'd be great if you could test our changes on your end, if you're interested in merging this pull request :)